### PR TITLE
Feature/260322_vim

### DIFF
--- a/.vim/base.vim
+++ b/.vim/base.vim
@@ -32,6 +32,9 @@ set hidden
 " 入力中のコマンドをステータスに表示する
 set showcmd
 
+" 補完メニューの最大表示件数を制限
+set pumheight=10
+
 " 検索パターンにマッチするテキストをすべて強調表示する
 set hlsearch
 

--- a/.vim/base.vim
+++ b/.vim/base.vim
@@ -35,6 +35,9 @@ set showcmd
 " 補完メニューの最大表示件数を制限
 set pumheight=10
 
+" 現在行をハイライト
+set cursorline
+
 " 検索パターンにマッチするテキストをすべて強調表示する
 set hlsearch
 

--- a/.vim/myplugin-config/indentline.vim
+++ b/.vim/myplugin-config/indentline.vim
@@ -1,0 +1,6 @@
+" 縦線を表示させるためconceallevelを設定
+set conceallevel=2
+let g:indentLine_conceallevel = 2
+
+" json, markdownではconceallevelの影響で文字が消えるため除外
+let g:indentLine_fileTypeExclude = ['json', 'markdown']

--- a/.vim/myplugin-config/tagbar.vim
+++ b/.vim/myplugin-config/tagbar.vim
@@ -1,0 +1,2 @@
+" <C-t> でtagbarのサイドバーをトグル
+nnoremap <silent> <C-t> :TagbarToggle<CR>

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -49,6 +49,9 @@ Plugin 'tpope/vim-unimpaired'
 " コメントトグル (gcc: 行, gc: ビジュアル範囲)
 Plugin 'tpope/vim-commentary'
 
+" インデントの縦線ガイド
+Plugin 'Yggdroot/indentLine'
+
 " status bar design
 "Plugin 'vim-airline/vim-airline'
 

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -46,6 +46,9 @@ Plugin 'Xuyuanp/nerdtree-git-plugin'
 " mapping
 Plugin 'tpope/vim-unimpaired'
 
+" コメントトグル (gcc: 行, gc: ビジュアル範囲)
+Plugin 'tpope/vim-commentary'
+
 " status bar design
 "Plugin 'vim-airline/vim-airline'
 

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -52,6 +52,9 @@ Plugin 'tpope/vim-commentary'
 " インデントの縦線ガイド
 Plugin 'Yggdroot/indentLine'
 
+" 関数・クラス一覧をサイドバー表示
+Plugin 'preservim/tagbar'
+
 " status bar design
 "Plugin 'vim-airline/vim-airline'
 

--- a/.vimrc
+++ b/.vimrc
@@ -7,4 +7,5 @@ source $HOME/dotfiles/.vim/myplugin-config/coc.vim
 source $HOME/dotfiles/.vim/myplugin-config/gitgutter.vim
 source $HOME/dotfiles/.vim/myplugin-config/fzf.vim
 source $HOME/dotfiles/.vim/myplugin-config/indentline.vim
+source $HOME/dotfiles/.vim/myplugin-config/tagbar.vim
 

--- a/.vimrc
+++ b/.vimrc
@@ -6,4 +6,5 @@ source $HOME/dotfiles/.vim/myplugin-config/nerd.vim
 source $HOME/dotfiles/.vim/myplugin-config/coc.vim
 source $HOME/dotfiles/.vim/myplugin-config/gitgutter.vim
 source $HOME/dotfiles/.vim/myplugin-config/fzf.vim
+source $HOME/dotfiles/.vim/myplugin-config/indentline.vim
 

--- a/.zshrc
+++ b/.zshrc
@@ -13,6 +13,11 @@ source "$ZSHRCDIR/base.zsh"
 source "$ZSHRCDIR/plugin.zsh"
 source "$ZSHRCDIR/option.zsh"
 
+# IME (ibus + mozc)
+export GTK_IM_MODULE=ibus
+export QT_IM_MODULE=ibus
+export XMODIFIERS=@im=ibus
+
 
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
 export SDKMAN_DIR="/home/ryogo-ito/.sdkman"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,14 @@
 ln -s ~/dotfiles/.vimrc ~/.vimrc
 
 source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/powerline.sh
+source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/vim_deps.sh
 
 powerline
 
-sudo apt install nodejs npm
+sudo apt install -y nodejs npm
 npm install -g yarn
 cd ~/.vim/bundle/coc.nvim
 yarn install
 cd ~
+
+vim_deps

--- a/scripts/lib/vim_deps.sh
+++ b/scripts/lib/vim_deps.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+set -ue
+
+function vim_deps() {
+    # tagbar: 関数・クラス一覧サイドバー
+    sudo apt install -y universal-ctags
+
+    # vim-instant-markdown: markdownプレビュー
+    npm install -g instant-markdown-d
+}
+
+vim_deps


### PR DESCRIPTION
## Summary
- `tpope/vim-commentary` を追加: `gcc` で行コメント、`gc` でビジュアル範囲のコメントをトグル
- ibus + mozc の IME 環境変数を `.zshrc` に追加 (`GTK_IM_MODULE`, `QT_IM_MODULE`, `XMODIFIERS`)
- `set pumheight=10`: 補完メニューの最大表示件数を10件に制限
- `set cursorline`: 現在行をハイライト
- `Yggdroot/indentLine` を追加: インデントの縦線ガイド（json/markdown は除外）
- `preservim/tagbar` を追加: 関数・クラス一覧をサイドバー表示（`<C-t>` でトグル）
- `scripts/lib/vim_deps.sh` を追加: プラグインに必要な外部ライブラリを一括インストール

## Related Issues
- Closes #8 (vim-commentary: gccで行コメントトグル)
- Closes #29 (set pumheight=10: 補完メニューの最大表示件数を制限)
- Closes #21 (set cursorline: 現在行をハイライト)
- Closes #11 (indentLine: インデントの縦線ガイド)
- Closes #14 (tagbar: 関数・クラス一覧をサイドバー表示)

## Test plan
- [x] `gcc` で行コメントのトグルが動作することを確認
- [x] `gc` + モーション / ビジュアル選択でコメントトグルが動作することを確認
- [x] ibus + mozc による日本語入力が正常に動作することを確認
- [x] 補完メニューが最大10件で表示されることを確認
- [x] 現在行がハイライトされることを確認
- [x] 2段以上のネストでインデントの縦線が表示されることを確認
- [x] json/markdown ではインデントガイドが表示されないことを確認
- [x] `<C-t>` でtagbarの開閉が動作することを確認
- [x] `install.sh` 実行で `universal-ctags` と `instant-markdown-d` がインストールされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)