### PR TITLE
feat: WezTerm で日本語IME (ibus) を使えるようにする

### DIFF
--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -54,6 +54,13 @@ return {
     ----------------------------------------------------
     -- fundamental settings
     ----------------------------------------------------
+    -- IME support
+    use_ime=true,
+    set_environment_variables={
+        XMODIFIERS='@im=ibus',
+        GTK_IM_MODULE='ibus',
+        QT_IM_MODULE='ibus',
+    },
     -- tab bar
     hide_tab_bar_if_only_one_tab=false,
     -- do not hold on exit by default

--- a/scripts/setup_wezterm_ime.sh
+++ b/scripts/setup_wezterm_ime.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# WezTerm (Flatpak) で日本語IMEを使えるようにする設定
+# Flatpakのサンドボックスにibus用の環境変数を注入する
+
+flatpak override --user --env=XMODIFIERS=@im=ibus org.wezfurlong.wezterm
+flatpak override --user --env=GTK_IM_MODULE=ibus org.wezfurlong.wezterm
+flatpak override --user --env=QT_IM_MODULE=ibus org.wezfurlong.wezterm
+
+echo "WezTerm IME setup done. Restart WezTerm to apply."


### PR DESCRIPTION
## Summary

- `.wezterm.lua` に `use_ime=true` と ibus 用の環境変数を追加
- Flatpak 版 WezTerm 向けのセットアップスクリプト `scripts/setup_wezterm_ime.sh` を追加

## Test plan

- [ ] WezTerm 起動後に日本語IME (ibus) が動作することを確認
- [ ] Flatpak 版の場合は `setup_wezterm_ime.sh` を実行してから再起動し、IMEが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)