### PR TITLE
refactor: zplug から antidote に移行する

### DIFF
--- a/.zsh/zsh_plugins.txt
+++ b/.zsh/zsh_plugins.txt
@@ -1,0 +1,4 @@
+romkatv/powerlevel10k
+zsh-users/zsh-completions
+junegunn/fzf path:shell/completion.zsh
+junegunn/fzf path:shell/key-bindings.zsh

--- a/.zsh/zshrc/plugin.zsh
+++ b/.zsh/zshrc/plugin.zsh
@@ -1,35 +1,12 @@
-# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
-# Initialization code that may require console input (password prompts, [y/n]
-# confirmations, etc.) must go above this block; everything else may go below.
-#if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
-#  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
-#fi
-#
-## zplug
-source ~/.zplug/init.zsh
+# antidote
+source ~/.antidote/antidote.zsh
 
-## theme
-zplug romkatv/powerlevel10k, as:theme, depth:1
-
-# 補完の強化
-zplug zsh-users/zsh-completions
-
-# fzf: ファジーファインダー
-# Ctrl+R: 履歴検索, Ctrl+T: ファイル検索, Alt+C: ディレクトリ移動
-zplug "junegunn/fzf", from:gh-r, as:command
-zplug "junegunn/fzf", use:"shell/*.zsh"
-
-# コマンドをリンクして、PATHに追加し、プラグインは読み込む
-zplug load --verbose > /dev/null 2>&1
+# 静的バンドル: zsh_plugins.txt が変わったときだけ再生成
+zsh_plugins_cache=${ZDOTDIR:-~}/.zsh_plugins.zsh
+if [[ ! $zsh_plugins_cache -nt $ZHOMEDIR/zsh_plugins.txt ]]; then
+  antidote bundle <$ZHOMEDIR/zsh_plugins.txt >$zsh_plugins_cache
+fi
+source $zsh_plugins_cache
 
 # fzf のデフォルトオプション
 export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
-
-# powerline
-#if [ -f /usr/share/powerline/bindings/zsh/powerline.zsh ]; then
-#    source /usr/share/powerline/bindings/zsh/powerline.zsh
-#fi
-
-# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
-[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
-

--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,10 @@
+# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
+# Initialization code that may require console input (password prompts, [y/n]
+# confirmations, etc.) must go above this block; everything else may go below.
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
 #==============================================================#
 #               .zshrc                                         #
 #==============================================================#
@@ -14,3 +21,6 @@ source "$ZSHRCDIR/alias.zsh"
 
 # profile (末尾で結果表示)
 [[ "$ZSHRC_PROFILE" != "" ]] && zprof
+
+# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
+[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh

--- a/scripts/lib/antidote.sh
+++ b/scripts/lib/antidote.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/bash
+
+set -ue
+
+function install_antidote(){
+    git clone --depth=1 https://github.com/mattmc3/antidote.git ~/.antidote
+}
+
+function install_fzf(){
+    sudo apt install -y fzf
+}
+
+install_antidote
+install_fzf


### PR DESCRIPTION
## Summary

- zplug（メンテナンス停止）から antidote に移行し、zsh 起動を高速化
- 静的バンドル（`~/.zsh_plugins.zsh` キャッシュ）を使い、`zsh_plugins.txt` 変更時のみ再生成
- fzf バイナリを `from:gh-r` ではなく apt で管理するよう変更

## Test plan

- [ ] `bash ~/dotfiles/scripts/lib/antidote.sh` で antidote・fzf がインストールされること
- [ ] `exec zsh` で初回起動時に `~/.zsh_plugins.zsh` が生成されること
- [ ] powerlevel10k・zsh-completions・fzf（補完・キーバインド）が正常に動作すること
- [ ] 2回目以降の起動がキャッシュを使って速くなっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)