### PR TITLE
feat: fd を導入して find を置き換える

### DIFF
--- a/.zsh/zshrc/alias.zsh
+++ b/.zsh/zshrc/alias.zsh
@@ -11,6 +11,9 @@ alias la="ls -laG"
 
 alias ...='cd ../..'
 
+# fd (Ubuntu では fdfind としてインストールされる)
+alias fd="fdfind"
+
 # wezterm
 alias wezterm="flatpak run org.wezfurlong.wezterm"
 

--- a/.zsh/zshrc/env.zsh
+++ b/.zsh/zshrc/env.zsh
@@ -1,3 +1,6 @@
+# fd + fzf 連携
+export FZF_DEFAULT_COMMAND="fd --type f --hidden --exclude .git"
+
 ## tmux用
 unset TMPDIR
 TMUX_TMPDIR=/tmp

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,7 @@ source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/vim_deps.sh
 
 powerline
 
-sudo apt install -y nodejs npm
+sudo apt install -y fd-find nodejs npm
 npm install -g yarn
 cd ~/.vim/bundle/coc.nvim
 yarn install


### PR DESCRIPTION
closes #50

## Summary

- `scripts/install.sh` に `fd-find` のインストールを追加
- `.zsh/zshrc/alias.zsh` に `alias fd="fdfind"` を追加（Ubuntu では `fdfind` としてインストールされるため）
- `.zsh/zshrc/env.zsh` に `FZF_DEFAULT_COMMAND` を設定し fzf と連携

🤖 Generated with [Claude Code](https://claude.com/claude-code)