### PR TITLE
feat: vim-instant-markdownをmarkdown-preview.nvimに移行する

### DIFF
--- a/.vim/myplugin-config/markdown-preview.vim
+++ b/.vim/myplugin-config/markdown-preview.vim
@@ -1,0 +1,5 @@
+let g:mkdp_auto_start = 0
+let g:mkdp_auto_close = 1
+let g:mkdp_preview_options = {
+  \ 'mermaid': {}
+  \ }

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -23,7 +23,7 @@ autocmd FileType python setlocal completeopt-=preview
 Plugin 'tomasr/molokai'
 
 " markdown preview
-Plugin 'suan/vim-instant-markdown'
+Plugin 'iamcco/markdown-preview.nvim'
 
 " file icons
 "Plugin 'ryanoasis/vim-devicons'

--- a/.vimrc
+++ b/.vimrc
@@ -8,4 +8,5 @@ source $HOME/dotfiles/.vim/myplugin-config/gitgutter.vim
 source $HOME/dotfiles/.vim/myplugin-config/fzf.vim
 source $HOME/dotfiles/.vim/myplugin-config/indentline.vim
 source $HOME/dotfiles/.vim/myplugin-config/tagbar.vim
+source $HOME/dotfiles/.vim/myplugin-config/markdown-preview.vim
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -19,6 +19,7 @@
 | **オートセーブ** | vim-auto-save |
 | **Undoツリー可視化** | gundo.vim |
 | **クイック実行** | vim-quickrun |
+| **Markdownプレビュー** | markdown-preview.nvim（`:MarkdownPreview`、Mermaid対応） |
 
 ## キーバインド
 | キー | 機能 |
@@ -45,6 +46,6 @@
 # Vundleをインストール
 git clone https://github.com/VundleVim/Vundle.vim ~/.vim/bundle/Vundle.vim
 
-# プラグインをインストール
-vim +PluginInstall +qall
+# プラグインをインストール・依存関係のセットアップ
+bash scripts/install.sh
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,4 +12,5 @@ cd ~/.vim/bundle/coc.nvim
 yarn install
 cd ~
 
+vim +PluginInstall +qall
 vim_deps

--- a/scripts/lib/vim_deps.sh
+++ b/scripts/lib/vim_deps.sh
@@ -6,8 +6,8 @@ function vim_deps() {
     # tagbar: 関数・クラス一覧サイドバー
     sudo apt install -y universal-ctags
 
-    # vim-instant-markdown: markdownプレビュー
-    npm install -g instant-markdown-d
+    # markdown-preview.nvim: markdownプレビュー（Mermaid対応）
+    vim -E -s -u NONE +"call mkdp#util#install()" +qa
 }
 
 vim_deps


### PR DESCRIPTION
closes #61

## Summary

- `plugin.vim`: `suan/vim-instant-markdown` を `iamcco/markdown-preview.nvim` に置き換え
- `.vim/myplugin-config/markdown-preview.vim`: Mermaid対応の設定ファイルを新規作成
- `scripts/install.sh`: `:PluginInstall` と依存関係インストールをスクリプト化
- `scripts/lib/vim_deps.sh`: `instant-markdown-d` の npm インストールを `mkdp#util#install()` に変更
- `docs/vim.md`: プラグイン情報とインストール手順を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)