### PR TITLE
feat: zsh-syntax-highlightingを導入する

### DIFF
--- a/.zsh/zsh_plugins.txt
+++ b/.zsh/zsh_plugins.txt
@@ -2,3 +2,5 @@ romkatv/powerlevel10k
 zsh-users/zsh-completions
 junegunn/fzf path:shell/completion.zsh
 junegunn/fzf path:shell/key-bindings.zsh
+zsh-users/zsh-autosuggestions
+zsh-users/zsh-syntax-highlighting

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -7,6 +7,8 @@
 | **テーマ** | Powerlevel10k |
 | **補完** | zsh-completions |
 | **ファジーファインダー** | fzf |
+| **シンタックスハイライト** | zsh-syntax-highlighting |
+| **コマンド候補表示** | zsh-autosuggestions |
 
 ## エイリアス
 | エイリアス | コマンド | 説明 |


### PR DESCRIPTION
closes #44

## Summary

- `zsh_plugins.txt` に `zsh-users/zsh-autosuggestions` と `zsh-users/zsh-syntax-highlighting` を追加
- `zsh-syntax-highlighting` は `zsh-autosuggestions` の後に記載し、ロード順を制御
- `docs/zsh.md` のプラグイン一覧に両プラグインを追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)