### PR TITLE
feat: auto-pairsプラグインを追加する

### DIFF
--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -138,6 +138,9 @@ endif
 Plugin 'junegunn/fzf', { 'do': { -> fzf#install() } }
 Plugin 'junegunn/fzf.vim'
 
+" 括弧・クォートの自動補完
+Plugin 'jiangmiao/auto-pairs'
+
 " html
 Plugin 'alvan/vim-closetag'
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -12,6 +12,7 @@
 | **ファジーファインダー** | fzf, fzf.vim |
 | **LaTeX** | vimtex |
 | **コードフォーマット** | vim-prettier |
+| **括弧・クォート自動補完** | auto-pairs |
 | **HTMLタグ補完** | vim-closetag |
 | **コメントトグル** | vim-commentary（`gcc`: 行, `gc`: ビジュアル範囲） |
 | **インデントガイド** | indentLine |


### PR DESCRIPTION
closes #9

## Summary

- `.vim/plugin.vim` に `jiangmiao/auto-pairs` プラグインを追加
- `docs/vim.md` に括弧・クォート自動補完の項目を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)