### PR TITLE
feat: vim-css-colorでCSSカラーコードを色付き表示する

### DIFF
--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -144,6 +144,9 @@ Plugin 'jiangmiao/auto-pairs'
 " html
 Plugin 'alvan/vim-closetag'
 
+" CSSカラーコードをその色で表示
+Plugin 'ap/vim-css-color'
+
 " All of your Plugins must be added before the following line
 call vundle#end()           " required
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -14,6 +14,7 @@
 | **コードフォーマット** | vim-prettier |
 | **括弧・クォート自動補完** | auto-pairs |
 | **HTMLタグ補完** | vim-closetag |
+| **CSSカラープレビュー** | vim-css-color（カラーコードをその色で表示） |
 | **コメントトグル** | vim-commentary（`gcc`: 行, `gc`: ビジュアル範囲） |
 | **タブ・末尾スペースの可視化** | `set list` + `listchars`（タブ: `▸`, 末尾スペース: `·`） |
 | **インデントガイド** | indentLine |


### PR DESCRIPTION
closes #13

## Summary

- `.vim/plugin.vim` に `ap/vim-css-color` を追加
- `docs/vim.md` にCSSカラープレビューの説明を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)