### PR TITLE
feat: macOS用インストールスクリプトを追加・OS判定を追加

### DIFF
--- a/.zsh/zshrc/alias.zsh
+++ b/.zsh/zshrc/alias.zsh
@@ -18,10 +18,14 @@ elif (( $+commands[bat] )); then
 fi
 
 # fd (Ubuntu では fdfind としてインストールされる)
-alias fd="fdfind"
+if (( $+commands[fdfind] )); then
+  alias fd="fdfind"
+fi
 
-# wezterm
-alias wezterm="flatpak run org.wezfurlong.wezterm"
+# wezterm (Ubuntu では flatpak 経由)
+if [[ "$(uname)" == "Linux" ]] && (( $+commands[flatpak] )); then
+  alias wezterm="flatpak run org.wezfurlong.wezterm"
+fi
 
 # branch
 _br() {

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -18,8 +18,8 @@
 | `la` | `eza -lah --git` | 隠しファイルも含む詳細表示 |
 | `lt` | `eza --tree --level=2` | ディレクトリツリー表示 |
 | `...` | `cd ../..` | 2階層上に移動 |
-| `fd` | `fdfind` | fd（Ubuntu向けエイリアス） |
-| `wezterm` | `flatpak run org.wezfurlong.wezterm` | WezTerm 起動 |
+| `fd` | `fdfind` | fd（Ubuntu向けエイリアス、`fdfind` が存在する場合のみ設定） |
+| `wezterm` | `flatpak run org.wezfurlong.wezterm` | WezTerm 起動（Linux + flatpak が存在する場合のみ設定） |
 | `bat` | `batcat` | bat（Ubuntu向けエイリアス） |
 | `cat` | `batcat --paging=never --style=plain`（Ubuntu）/ `bat --paging=never --style=plain`（macOS） | シンタックスハイライト付きファイル表示 |
 

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -18,7 +18,7 @@
 | `la` | `eza -lah --git` | 隠しファイルも含む詳細表示 |
 | `lt` | `eza --tree --level=2` | ディレクトリツリー表示 |
 | `...` | `cd ../..` | 2階層上に移動 |
-| `fd` | `fdfind` | fd（Ubuntu向けエイリアス、`fdfind` が存在する場合のみ設定） |
+| `fd` | `fdfind` | fd（`fdfind` コマンドが存在する場合のみ設定、Ubuntu向け） |
 | `wezterm` | `flatpak run org.wezfurlong.wezterm` | WezTerm 起動（Linux + flatpak が存在する場合のみ設定） |
 | `bat` | `batcat` | bat（Ubuntu向けエイリアス） |
 | `cat` | `batcat --paging=never --style=plain`（Ubuntu）/ `bat --paging=never --style=plain`（macOS） | シンタックスハイライト付きファイル表示 |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,8 @@ source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/vim_deps.sh
 source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/git.sh
 
 powerline
+install_delta
+setup_gitconfig
 
 sudo apt install -y eza fd-find nodejs npm groff
 # bat は Ubuntu 22.04以降のみ apt でインストール可能

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -ue
+
 ln -s ~/dotfiles/.vimrc ~/.vimrc
 
 source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/powerline.sh

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -21,6 +21,9 @@ ln -s ~/dotfiles/.vimrc ~/.vimrc
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/lib/vim_deps.sh"
 source "$(dirname "${BASH_SOURCE[0]:-$0}")/lib/git.sh"
 
+install_delta
+setup_gitconfig
+
 brew install eza fd bat node groff
 
 brew install --cask wezterm
@@ -31,3 +34,4 @@ yarn install
 cd ~
 
 vim +PluginInstall +qall
+vim_deps

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -31,4 +31,3 @@ yarn install
 cd ~
 
 vim +PluginInstall +qall
-vim_deps

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -ue
+
+# macOS チェック
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "エラー: このスクリプトは macOS 専用です。"
+  echo "Ubuntu の場合は scripts/install.sh を使ってください。"
+  exit 1
+fi
+
+# Homebrew の確認
+if ! command -v brew &>/dev/null; then
+  echo "エラー: Homebrew がインストールされていません。"
+  echo "以下のコマンドでインストールしてください:"
+  echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+  exit 1
+fi
+
+ln -s ~/dotfiles/.vimrc ~/.vimrc
+
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/lib/vim_deps.sh"
+source "$(dirname "${BASH_SOURCE[0]:-$0}")/lib/git.sh"
+
+brew install eza fd bat node groff
+
+brew install --cask wezterm
+
+npm install -g yarn
+cd ~/.vim/bundle/coc.nvim
+yarn install
+cd ~
+
+vim +PluginInstall +qall
+vim_deps

--- a/scripts/lib/git.sh
+++ b/scripts/lib/git.sh
@@ -3,7 +3,11 @@
 set -ue
 
 function install_delta() {
-    sudo apt install -y git-delta
+    if [[ "$(uname)" == "Darwin" ]]; then
+        brew install git-delta
+    else
+        sudo apt install -y git-delta
+    fi
 }
 
 function setup_gitconfig() {

--- a/scripts/lib/git.sh
+++ b/scripts/lib/git.sh
@@ -28,6 +28,3 @@ EOF
 
     echo "~/.gitconfig を作成しました"
 }
-
-install_delta
-setup_gitconfig

--- a/scripts/lib/powerline.sh
+++ b/scripts/lib/powerline.sh
@@ -6,5 +6,3 @@ function powerline(){
     pip3 install  powerline-status
     pip3 install  powerline-shell
 }
-
-powerline

--- a/scripts/lib/vim_deps.sh
+++ b/scripts/lib/vim_deps.sh
@@ -4,7 +4,11 @@ set -ue
 
 function vim_deps() {
     # tagbar: 関数・クラス一覧サイドバー
-    sudo apt install -y universal-ctags
+    if [[ "$(uname)" == "Darwin" ]]; then
+        brew install universal-ctags
+    else
+        sudo apt install -y universal-ctags
+    fi
 
     # markdown-preview.nvim: markdownプレビュー（Mermaid対応）
     vim -E -s -u NONE +"call mkdp#util#install()" +qa

--- a/scripts/lib/vim_deps.sh
+++ b/scripts/lib/vim_deps.sh
@@ -13,5 +13,3 @@ function vim_deps() {
     # markdown-preview.nvim: markdownプレビュー（Mermaid対応）
     vim -E -s -u NONE +"call mkdp#util#install()" +qa
 }
-
-vim_deps


### PR DESCRIPTION
closes #70

## Summary

- `scripts/install_mac.sh` を新規作成（macOSチェック・brewチェック付き）
- `.zsh/zshrc/alias.zsh` の `fd`・`wezterm` エイリアスにOS判定を追加
- `scripts/lib/git.sh`・`scripts/lib/vim_deps.sh` にOS判定を追加（macOSではbrew使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)