### PR TITLE
feat: vim-illuminateでカーソル下の識別子を自動ハイライト

### DIFF
--- a/.vim/myplugin-config/illuminate.vim
+++ b/.vim/myplugin-config/illuminate.vim
@@ -1,0 +1,10 @@
+" vim-illuminate: カーソル下の識別子を自動ハイライト
+
+" ハイライトまでの遅延時間 (ms)
+let g:Illuminate_delay = 250
+
+" coc.nvim のLSPハイライトを優先するため、illuminate のハイライトを無効化しない
+" (両方有効にすることで補完として機能する)
+
+" 特定のファイルタイプではハイライトを無効化
+let g:Illuminate_ftblacklist = ['NERDTree', 'tagbar', 'fzf']

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -124,6 +124,9 @@ Plugin 'prettier/vim-prettier'
 " Language Server
 Plugin 'neoclide/coc.nvim', {'branch': 'release'}
 
+" カーソル下の識別子を自動ハイライト
+Plugin 'RRethy/vim-illuminate'
+
 " Git
 Plugin 'tpope/vim-fugitive'
 Plugin 'airblade/vim-gitgutter'

--- a/.vimrc
+++ b/.vimrc
@@ -9,4 +9,5 @@ source $HOME/dotfiles/.vim/myplugin-config/fzf.vim
 source $HOME/dotfiles/.vim/myplugin-config/indentline.vim
 source $HOME/dotfiles/.vim/myplugin-config/tagbar.vim
 source $HOME/dotfiles/.vim/myplugin-config/markdown-preview.vim
+source $HOME/dotfiles/.vim/myplugin-config/illuminate.vim
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -9,6 +9,7 @@
 | **補完エンジン** | coc.nvim |
 | **ステータスライン** | Powerline（Vim）/ vim-airline（Neovim） |
 | **Git連携** | vim-fugitive, vim-gitgutter |
+| **識別子ハイライト** | vim-illuminate（カーソル下の識別子を自動ハイライト） |
 | **ファジーファインダー** | fzf, fzf.vim |
 | **LaTeX** | vimtex |
 | **コードフォーマット** | vim-prettier |


### PR DESCRIPTION
closes #77

## Summary

- `Plugin 'RRethy/vim-illuminate'` を `.vim/plugin.vim` に追加
- `.vim/myplugin-config/illuminate.vim` を新規作成（遅延250ms、NERDTree/tagbar/fzfでは無効化）
- `.vimrc` に `illuminate.vim` の source を追加
- `docs/vim.md` のプラグイン一覧に vim-illuminate を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)