### PR TITLE
feat: naviでコマンドチートシートをターミナル内で検索

### DIFF
--- a/.zsh/zshrc/env.zsh
+++ b/.zsh/zshrc/env.zsh
@@ -45,3 +45,6 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 export SDKMAN_DIR="$HOME/.sdkman"
 export SDKMAN_CANDIDATES_DIR="$SDKMAN_DIR/candidates"
 [[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"
+
+# navi (command cheatsheet, Ctrl+G)
+command -v navi &>/dev/null && eval "$(navi widget zsh)"

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -42,6 +42,12 @@ fzf プラグイン（`junegunn/fzf`）が提供するキーバインド：
 | `Ctrl+T` | カレントディレクトリ以下のファイルをファジー検索してコマンドラインに挿入 |
 | `Alt+C` | ディレクトリをファジー検索して cd |
 
+navi が提供するキーバインド：
+
+| キー | 機能 |
+|------|------|
+| `Ctrl+G` | コマンドチートシートをファジー検索してコマンドラインに挿入 |
+
 補完：
 
 | キー | 機能 |
@@ -53,6 +59,12 @@ fzf プラグイン（`junegunn/fzf`）が提供するキーバインド：
 ## fzf
 - デフォルトオプション: `--height 40% --layout=reverse --border`
 - `FZF_DEFAULT_COMMAND`: `fd --type f --hidden --exclude .git`（fd と連携）
+
+## navi
+- `Ctrl+G` でコマンドのチートシートをファジー検索できる
+- コミュニティのチートシート（[denisidoro/cheats](https://github.com/denisidoro/cheats)）が利用可能
+- 自前のチートシートを追加して育てることもできる
+- インストール: `cargo install navi`（Rust / cargo が必要）
 
 ## 対応する開発環境
 - **Python**: pyenv

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,14 @@ else
   echo "    https://github.com/sharkdp/bat/releases"
 fi
 npm install -g yarn
+
+# navi (command cheatsheet) — cargo が利用可能な場合にインストール
+if command -v cargo &>/dev/null; then
+  cargo install navi
+else
+  echo "⚠️  cargo が見つかりませんでした。navi をインストールするには Rust をインストールしてください:"
+  echo "    https://rustup.rs/"
+fi
 cd ~/.vim/bundle/coc.nvim
 yarn install
 cd ~


### PR DESCRIPTION
closes #100

## Summary

- `.zsh/zshrc/env.zsh` に `navi widget zsh` の設定を追加（naviがインストール済みの場合のみ有効化）
- `scripts/install.sh` に cargo 経由での navi インストール処理を追加
- `docs/zsh.md` にキーバインド（`Ctrl+G`）と navi セクションを追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)