### PR TITLE
feat: MesloLGS NFフォントのインストール処理をinstall.shに追加

### DIFF
--- a/docs/wezterm.md
+++ b/docs/wezterm.md
@@ -8,6 +8,11 @@
 | **日時表示** | 右ステータスに表示 |
 | **IME** | ibus 対応（`use_ime = true`） |
 | **フォントサイズ** | 13 |
+| **フォント** | MesloLGS NF（fallback: Noto Sans Mono CJK JP, Noto Color Emoji） |
+
+## フォント
+
+`MesloLGS NF` を使用している。`scripts/install.sh` によって `~/.local/share/fonts/` にインストールされる。
 
 ## キーバインド
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,16 @@ powerline
 install_delta
 setup_gitconfig
 
-sudo apt install -y eza fd-find nodejs npm groff fonts-noto-cjk
+sudo apt install -y eza fd-find nodejs npm groff fonts-noto-cjk fontconfig
+
+# MesloLGS NF (powerlevel10k推奨フォント)
+FONT_DIR="$HOME/.local/share/fonts"
+mkdir -p "$FONT_DIR"
+MESLOLGS_BASE="https://github.com/romkatv/powerlevel10k-media/raw/master"
+for font in "MesloLGS NF Regular" "MesloLGS NF Bold" "MesloLGS NF Italic" "MesloLGS NF Bold Italic"; do
+  curl -fsSL "${MESLOLGS_BASE}/${font// /%20}.ttf" -o "${FONT_DIR}/${font}.ttf"
+done
+fc-cache -f "$FONT_DIR"
 
 # lazygit — GitHubリリースからバイナリをインストール
 LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')


### PR DESCRIPTION
closes #107

## Summary

- `scripts/install.sh` にMesloLGS NFフォント（Regular/Bold/Italic/Bold Italic）のインストール処理を追加
- powerlevel10kのGitHubリポジトリからダウンロードし `~/.local/share/fonts/` に配置
- `fc-cache -f` でフォントキャッシュを更新
- `docs/wezterm.md` にフォント設定の説明を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)