### PR TITLE
feat: Vim内からキーバインド一覧を確認できるようにする

### DIFF
--- a/.vim/myplugin-config/which-key.vim
+++ b/.vim/myplugin-config/which-key.vim
@@ -1,0 +1,82 @@
+" vim-which-key: リーダーキー押下時にキーバインド一覧をポップアップ表示
+
+" プラグインが未インストールの場合はスキップ
+if empty(globpath(&rtp, 'autoload/which_key.vim'))
+  finish
+endif
+
+" ポップアップ表示の遅延（ms）
+set timeoutlen=500
+
+" --- <leader> キーマップ定義 ---
+let g:which_key_map = {}
+
+let g:which_key_map['s'] = 'カーソル下の単語を検索'
+let g:which_key_map['b'] = 'バッファ一覧'
+let g:which_key_map['r'] = { 'name': 'Rename' }
+let g:which_key_map['r']['n'] = 'シンボルのリネーム (coc)'
+let g:which_key_map['f'] = 'フォーマット (coc)'
+let g:which_key_map['a'] = 'コードアクション (coc)'
+let g:which_key_map['q'] = { 'name': 'Quick Fix' }
+let g:which_key_map['q']['f'] = 'クイックフィックス (coc)'
+
+call which_key#register('\', "g:which_key_map")
+
+nnoremap <silent> <leader> :<c-u>WhichKey '\'<CR>
+vnoremap <silent> <leader> :<c-u>WhichKeyVisual '\'<CR>
+
+" --- <space> キーマップ定義 ---
+let g:which_key_space_map = {}
+
+let g:which_key_space_map['a'] = '診断一覧 (coc)'
+let g:which_key_space_map['e'] = '拡張機能一覧 (coc)'
+let g:which_key_space_map['c'] = 'コマンド一覧 (coc)'
+let g:which_key_space_map['o'] = 'アウトライン (coc)'
+let g:which_key_space_map['s'] = 'シンボル一覧 (coc)'
+let g:which_key_space_map['j'] = '次の診断へ (coc)'
+let g:which_key_space_map['k'] = '前の診断へ (coc)'
+let g:which_key_space_map['p'] = 'CocListを再開'
+
+call which_key#register('<Space>', "g:which_key_space_map")
+
+nnoremap <silent> <space> :<c-u>WhichKey '<Space>'<CR>
+vnoremap <silent> <space> :<c-u>WhichKeyVisual '<Space>'<CR>
+
+" --- fzfで日本語説明付きキーバインド一覧を表示 ---
+let s:keymaps = [
+  \ 'n   <C-p>        ファイル検索 (fzf)',
+  \ 'n   <C-f>        テキスト全体検索 (ripgrep)',
+  \ 'n   <C-e>        NERDTreeトグル',
+  \ 'n   <C-t>        Tagbarトグル',
+  \ 'n   <leader>s    カーソル下の単語をプロジェクト全体で検索',
+  \ 'n   <leader>b    バッファ一覧',
+  \ 'n   <leader>rn   シンボルのリネーム (coc)',
+  \ 'n   <leader>f    フォーマット (coc)',
+  \ 'n   <leader>a    コードアクション (coc)',
+  \ 'n   <leader>ac   コードアクション（バッファ全体）(coc)',
+  \ 'n   <leader>qf   クイックフィックス (coc)',
+  \ 'n   gd           定義へジャンプ (coc)',
+  \ 'n   gy           型定義へジャンプ (coc)',
+  \ 'n   gi           実装へジャンプ (coc)',
+  \ 'n   gr           参照を表示 (coc)',
+  \ 'n   K            ドキュメント表示 (coc)',
+  \ 'n   <space>a     診断一覧 (coc)',
+  \ 'n   <space>e     拡張機能一覧 (coc)',
+  \ 'n   <space>c     コマンド一覧 (coc)',
+  \ 'n   <space>o     アウトライン (coc)',
+  \ 'n   <space>s     シンボル一覧 (coc)',
+  \ 'n   <space>j     次の診断へ (coc)',
+  \ 'n   <space>k     前の診断へ (coc)',
+  \ 'n   <space>p     CocListを再開',
+  \ 'n   <leader>?    このキーバインド一覧を表示',
+  \ ]
+
+function! s:show_keymaps()
+  call fzf#run(fzf#wrap({
+    \ 'source': s:keymaps,
+    \ 'options': ['--prompt', 'Keymaps> ', '--no-multi'],
+    \ }))
+endfunction
+
+command! Keymaps call s:show_keymaps()
+nnoremap <silent> <leader>? :Keymaps<CR>

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -141,6 +141,9 @@ endif
 Plugin 'junegunn/fzf', { 'do': { -> fzf#install() } }
 Plugin 'junegunn/fzf.vim'
 
+" キーバインド一覧をポップアップ表示
+Plugin 'liuchengxu/vim-which-key'
+
 " 括弧・クォートの自動補完
 Plugin 'jiangmiao/auto-pairs'
 

--- a/.vimrc
+++ b/.vimrc
@@ -10,4 +10,5 @@ source $HOME/dotfiles/.vim/myplugin-config/indentline.vim
 source $HOME/dotfiles/.vim/myplugin-config/tagbar.vim
 source $HOME/dotfiles/.vim/myplugin-config/markdown-preview.vim
 source $HOME/dotfiles/.vim/myplugin-config/illuminate.vim
+source $HOME/dotfiles/.vim/myplugin-config/which-key.vim
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -24,6 +24,7 @@
 | **Undoツリー可視化** | gundo.vim |
 | **クイック実行** | vim-quickrun |
 | **Markdownプレビュー** | markdown-preview.nvim（`:MarkdownPreview`、Mermaid対応） |
+| **キーバインド表示** | vim-which-key（`<leader>` or `<space>` 押下でポップアップ表示） |
 
 ## キーバインド
 | キー | 機能 |
@@ -33,6 +34,7 @@
 | `Ctrl+F` | テキスト全体検索（fzf + ripgrep） |
 | `<leader>s` | カーソル下の単語をプロジェクト全体で検索（fzf + ripgrep） |
 | `<leader>b` | バッファ一覧（fzf） |
+| `<leader>?` | キーバインド一覧（fzf、日本語説明付き） |
 
 ## coc.nvim キーバインド
 | キー | 機能 |


### PR DESCRIPTION
closes #111

## Summary

- `vim-which-key` プラグインを追加。`<leader>` または `<space>` を押して待つとポップアップでキーバインド一覧を表示
- `<leader>?` で fzf による日本語説明付きキーバインド一覧を表示する `:Keymaps` コマンドを追加
- `docs/vim.md` に追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)