### PR TITLE
feat: forgitでfzf UIからgit操作を行えるようにする

### DIFF
--- a/.zsh/zsh_plugins.txt
+++ b/.zsh/zsh_plugins.txt
@@ -4,3 +4,4 @@ junegunn/fzf path:shell/completion.zsh
 junegunn/fzf path:shell/key-bindings.zsh
 zsh-users/zsh-autosuggestions
 zsh-users/zsh-syntax-highlighting
+wfxr/forgit

--- a/docs/git.md
+++ b/docs/git.md
@@ -26,6 +26,20 @@
 sudo apt install git-delta
 ```
 
+## forgit
+
+fzf のインタラクティブUIで git 操作を行える zsh プラグイン。
+
+| コマンド | 機能 |
+|---------|------|
+| `ga` | `git add` をfzfで選択 |
+| `glo` | `git log` をfzfで閲覧 |
+| `gd` | `git diff` をfzfで閲覧 |
+| `gcb` | `git checkout` ブランチをfzfで選択 |
+| `gco` | `git checkout` ファイルをfzfで選択 |
+| `grh` | `git reset HEAD` をfzfで選択 |
+| `gss` | `git stash show` をfzfで選択 |
+
 ## ユーザー情報の設定
 
 `~/.gitconfig` はスクリプトで生成する（ユーザー情報は `.gitconfig_example` に含めない）。

--- a/scripts/lib/antidote.sh
+++ b/scripts/lib/antidote.sh
@@ -7,7 +7,8 @@ function install_antidote(){
 }
 
 function install_fzf(){
-    sudo apt install -y fzf
+    git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
+    ~/.fzf/install --all
 }
 
 install_antidote


### PR DESCRIPTION
closes #99

## Summary

- `.zsh/zsh_plugins.txt` に `wfxr/forgit` を追加
- `docs/git.md` に forgit のコマンド一覧セクションを追加
- `scripts/lib/antidote.sh` の fzf インストールを apt から GitHub クローンに変更（forgit が fzf 0.60.0 以上を要求するため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)