### PR TITLE
feat: vim-floatermでフローティングターミナルをvim内で起動

### DIFF
--- a/.vim/myplugin-config/floaterm.vim
+++ b/.vim/myplugin-config/floaterm.vim
@@ -1,0 +1,18 @@
+" vim-floaterm: フローティングターミナル
+
+" プラグインが未インストールの場合はスキップ
+if empty(globpath(&rtp, 'autoload/floaterm.vim'))
+  finish
+endif
+
+" ウィンドウのサイズ・位置設定
+let g:floaterm_width = 0.85
+let g:floaterm_height = 0.85
+let g:floaterm_position = 'center'
+
+" フローティングターミナルをトグル
+nnoremap <silent> <leader>t :FloatermToggle<CR>
+tnoremap <silent> <leader>t <C-\><C-n>:FloatermToggle<CR>
+
+" lazygitを起動
+nnoremap <silent> <leader>g :FloatermNew --title=lazygit lazygit<CR>

--- a/.vim/myplugin-config/which-key.vim
+++ b/.vim/myplugin-config/which-key.vim
@@ -11,6 +11,8 @@ set timeoutlen=500
 " --- <leader> キーマップ定義 ---
 let g:which_key_map = {}
 
+let g:which_key_map['t'] = 'フローティングターミナルをトグル (floaterm)'
+let g:which_key_map['g'] = 'lazygitを起動 (floaterm)'
 let g:which_key_map['s'] = 'カーソル下の単語を検索'
 let g:which_key_map['b'] = 'バッファ一覧'
 let g:which_key_map['r'] = { 'name': 'Rename' }
@@ -68,6 +70,8 @@ let s:keymaps = [
   \ 'n   <space>j     次の診断へ (coc)',
   \ 'n   <space>k     前の診断へ (coc)',
   \ 'n   <space>p     CocListを再開',
+  \ 'n   <leader>t    フローティングターミナルをトグル (floaterm)',
+  \ 'n   <leader>g    lazygitを起動 (floaterm)',
   \ 'n   <leader>?    このキーバインド一覧を表示',
   \ ]
 

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -131,6 +131,9 @@ Plugin 'RRethy/vim-illuminate'
 Plugin 'tpope/vim-fugitive'
 Plugin 'airblade/vim-gitgutter'
 
+" フローティングターミナル
+Plugin 'voldikss/vim-floaterm'
+
 " vim-airline
 if has('nvim')
     Plugin 'vim-airline/vim-airline'

--- a/.vimrc
+++ b/.vimrc
@@ -12,4 +12,5 @@ source $HOME/dotfiles/.vim/myplugin-config/markdown-preview.vim
 source $HOME/dotfiles/.vim/myplugin-config/illuminate.vim
 source $HOME/dotfiles/.vim/myplugin-config/which-key.vim
 source $HOME/dotfiles/.vim/myplugin-config/highlightedyank.vim
+source $HOME/dotfiles/.vim/myplugin-config/floaterm.vim
 

--- a/.zshrc
+++ b/.zshrc
@@ -24,3 +24,5 @@ source "$ZSHRCDIR/alias.zsh"
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
+
+[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -9,6 +9,7 @@
 | **補完エンジン** | coc.nvim |
 | **ステータスライン** | Powerline（Vim）/ vim-airline（Neovim） |
 | **Git連携** | vim-fugitive, vim-gitgutter |
+| **フローティングターミナル** | vim-floaterm（`<leader>t`: ターミナル, `<leader>g`: lazygit） |
 | **識別子ハイライト** | vim-illuminate（カーソル下の識別子を自動ハイライト） |
 | **ファジーファインダー** | fzf, fzf.vim |
 | **LaTeX** | vimtex |
@@ -36,6 +37,8 @@
 | `<leader>s` | カーソル下の単語をプロジェクト全体で検索（fzf + ripgrep） |
 | `<leader>b` | バッファ一覧（fzf） |
 | `<leader>?` | キーバインド一覧（fzf、日本語説明付き） |
+| `<leader>t` | フローティングターミナルをトグル（vim-floaterm） |
+| `<leader>g` | lazygitをフローティングウィンドウで起動（vim-floaterm） |
 
 ## coc.nvim キーバインド
 | キー | 機能 |


### PR DESCRIPTION
closes #76

## Summary

- `.vim/plugin.vim` に `voldikss/vim-floaterm` を追加
- `.vim/myplugin-config/floaterm.vim` を新規作成（ウィンドウサイズ設定・キーマップ）
- `.vim/myplugin-config/which-key.vim` に `<leader>t`, `<leader>g` を追加
- `docs/vim.md` にfloatermの設定・キーバインドを追記
- `.vimrc` に `floaterm.vim` の source を追加（読み込み漏れ修正）
- `.zshrc` にfzfインストール時に自動追記された `~/.fzf.zsh` の source を追加

## キーバインド

| キー | 機能 |
|------|------|
| `<leader>t` | フローティングターミナルをトグル |
| `<leader>g` | lazygitをフローティングウィンドウで起動 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)