### PR TITLE
feat: ripgrepをgrepのエイリアスとして設定する

### DIFF
--- a/.zsh/zshrc/alias.zsh
+++ b/.zsh/zshrc/alias.zsh
@@ -27,6 +27,11 @@ if [[ "$(uname)" == "Linux" ]] && (( $+commands[flatpak] )); then
   alias wezterm="flatpak run org.wezfurlong.wezterm"
 fi
 
+# ripgrep (grep の置き換え)
+if (( $+commands[rg] )); then
+  alias grep="rg"
+fi
+
 # branch
 _br() {
   git branch --show-current

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -19,6 +19,7 @@
 | `lt` | `eza --tree --level=2` | ディレクトリツリー表示 |
 | `...` | `cd ../..` | 2階層上に移動 |
 | `fd` | `fdfind` | fd（`fdfind` コマンドが存在する場合のみ設定、Ubuntu向け） |
+| `grep` | `rg` | ripgrep（`rg` コマンドが存在する場合のみ設定） |
 | `wezterm` | `flatpak run org.wezfurlong.wezterm` | WezTerm 起動（Linux + flatpak が存在する場合のみ設定） |
 | `bat` | `batcat` | bat（Ubuntu向けエイリアス） |
 | `cat` | `batcat --paging=never --style=plain`（Ubuntu）/ `bat --paging=never --style=plain`（macOS） | シンタックスハイライト付きファイル表示 |


### PR DESCRIPTION
closes #51

## Summary

- `.zsh/zshrc/alias.zsh` に `alias grep="rg"` を追加（`rg` が存在する場合のみ有効）
- `docs/zsh.md` のエイリアス一覧に `grep` → `rg` を追記
- `ripgrep` 自体は `scripts/install.sh` にすでに含まれているためインストール変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)