### PR TITLE
feat: vim-testでVim内からテストを実行

### DIFF
--- a/.vim/myplugin-config/floaterm.vim
+++ b/.vim/myplugin-config/floaterm.vim
@@ -11,8 +11,8 @@ let g:floaterm_height = 0.85
 let g:floaterm_position = 'center'
 
 " フローティングターミナルをトグル
-nnoremap <silent> <leader>t :FloatermToggle<CR>
-tnoremap <silent> <leader>t <C-\><C-n>:FloatermToggle<CR>
+nnoremap <silent> <leader>tt :FloatermToggle<CR>
+tnoremap <silent> <leader>tt <C-\><C-n>:FloatermToggle<CR>
 
 " lazygitを起動
 nnoremap <silent> <leader>g :FloatermNew --title=lazygit lazygit<CR>

--- a/.vim/myplugin-config/vim-test.vim
+++ b/.vim/myplugin-config/vim-test.vim
@@ -1,0 +1,14 @@
+" vim-test: Vim内からテストを実行
+
+" プラグインが未インストールの場合はスキップ
+if empty(globpath(&rtp, 'autoload/test.vim')) && !exists('g:loaded_test')
+  finish
+endif
+
+" vim-floatermと連携
+let g:test#strategy = 'floaterm'
+
+nmap <silent> <leader>tn :TestNearest<CR>
+nmap <silent> <leader>tf :TestFile<CR>
+nmap <silent> <leader>ts :TestSuite<CR>
+nmap <silent> <leader>tl :TestLast<CR>

--- a/.vim/myplugin-config/which-key.vim
+++ b/.vim/myplugin-config/which-key.vim
@@ -11,7 +11,12 @@ set timeoutlen=500
 " --- <leader> キーマップ定義 ---
 let g:which_key_map = {}
 
-let g:which_key_map['t'] = 'フローティングターミナルをトグル (floaterm)'
+let g:which_key_map['t'] = { 'name': 'Terminal / Test' }
+let g:which_key_map['t']['t'] = 'フローティングターミナルをトグル (floaterm)'
+let g:which_key_map['t']['n'] = '最近傍テストを実行 (vim-test)'
+let g:which_key_map['t']['f'] = 'ファイル内テストを実行 (vim-test)'
+let g:which_key_map['t']['s'] = 'テストスイートを実行 (vim-test)'
+let g:which_key_map['t']['l'] = '最後のテストを再実行 (vim-test)'
 let g:which_key_map['g'] = 'lazygitを起動 (floaterm)'
 let g:which_key_map['s'] = 'カーソル下の単語を検索'
 let g:which_key_map['b'] = 'バッファ一覧'
@@ -70,8 +75,12 @@ let s:keymaps = [
   \ 'n   <space>j     次の診断へ (coc)',
   \ 'n   <space>k     前の診断へ (coc)',
   \ 'n   <space>p     CocListを再開',
-  \ 'n   <leader>t    フローティングターミナルをトグル (floaterm)',
+  \ 'n   <leader>tt   フローティングターミナルをトグル (floaterm)',
   \ 'n   <leader>g    lazygitを起動 (floaterm)',
+  \ 'n   <leader>tn   最近傍テストを実行 (vim-test)',
+  \ 'n   <leader>tf   ファイル内テストを実行 (vim-test)',
+  \ 'n   <leader>ts   テストスイートを実行 (vim-test)',
+  \ 'n   <leader>tl   最後のテストを再実行 (vim-test)',
   \ 'n   <leader>?    このキーバインド一覧を表示',
   \ ]
 

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -134,6 +134,9 @@ Plugin 'airblade/vim-gitgutter'
 " フローティングターミナル
 Plugin 'voldikss/vim-floaterm'
 
+" テストランナー
+Plugin 'vim-test/vim-test'
+
 " vim-airline
 if has('nvim')
     Plugin 'vim-airline/vim-airline'

--- a/.vimrc
+++ b/.vimrc
@@ -13,4 +13,5 @@ source $HOME/dotfiles/.vim/myplugin-config/illuminate.vim
 source $HOME/dotfiles/.vim/myplugin-config/which-key.vim
 source $HOME/dotfiles/.vim/myplugin-config/highlightedyank.vim
 source $HOME/dotfiles/.vim/myplugin-config/floaterm.vim
+source $HOME/dotfiles/.vim/myplugin-config/vim-test.vim
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -9,7 +9,8 @@
 | **補完エンジン** | coc.nvim |
 | **ステータスライン** | Powerline（Vim）/ vim-airline（Neovim） |
 | **Git連携** | vim-fugitive, vim-gitgutter |
-| **フローティングターミナル** | vim-floaterm（`<leader>t`: ターミナル, `<leader>g`: lazygit） |
+| **フローティングターミナル** | vim-floaterm（`<leader>tt`: ターミナル, `<leader>g`: lazygit） |
+| **テストランナー** | vim-test（`<leader>tn`: nearest, `<leader>tf`: file, `<leader>ts`: suite, `<leader>tl`: last） |
 | **識別子ハイライト** | vim-illuminate（カーソル下の識別子を自動ハイライト） |
 | **ファジーファインダー** | fzf, fzf.vim |
 | **LaTeX** | vimtex |
@@ -37,8 +38,12 @@
 | `<leader>s` | カーソル下の単語をプロジェクト全体で検索（fzf + ripgrep） |
 | `<leader>b` | バッファ一覧（fzf） |
 | `<leader>?` | キーバインド一覧（fzf、日本語説明付き） |
-| `<leader>t` | フローティングターミナルをトグル（vim-floaterm） |
+| `<leader>tt` | フローティングターミナルをトグル（vim-floaterm） |
 | `<leader>g` | lazygitをフローティングウィンドウで起動（vim-floaterm） |
+| `<leader>tn` | 最近傍テストを実行（vim-test） |
+| `<leader>tf` | ファイル内テストを実行（vim-test） |
+| `<leader>ts` | テストスイートを実行（vim-test） |
+| `<leader>tl` | 最後のテストを再実行（vim-test） |
 
 ## coc.nvim キーバインド
 | キー | 機能 |


### PR DESCRIPTION
closes #81

## Summary

- `vim-test/vim-test` プラグインを追加
- vim-floatermと連携してフローティングウィンドウでテスト結果を表示
- `\tn` (nearest), `\tf` (file), `\ts` (suite), `\tl` (last) のキーバインドを追加
- floatermトグルを `\t` から `\tt` に変更してサブグループを整理
- which-keyに `\t` グループとして全キーバインドを登録
- docs/vim.md を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)