### PR TITLE
feat: tmux-continuumでセッションを自動保存・自動復元

### DIFF
--- a/.tmux/plugin.tmux
+++ b/.tmux/plugin.tmux
@@ -11,4 +11,9 @@ run '~/.tmux/plugins/tpm/tpm'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @resurrect-strategy-vim 'session'
 
+# tmux-continuumでセッションを自動保存・自動復元（tmux-resurrectの後に読み込む）
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
+
 

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -9,6 +9,17 @@
 | **ペイン移動** | Vim形式（`h`, `j`, `k`, `l`） |
 | **コピーモード** | Vimキーバインド |
 
+## プラグイン
+
+| プラグイン | 説明 |
+|-----------|------|
+| **tpm** | プラグインマネージャー |
+| **tmux-sensible** | 基本設定の最適化 |
+| **tmux-resurrect** | セッションの手動保存・復元（`prefix+Ctrl+s`: 保存, `prefix+Ctrl+r`: 復元） |
+| **tmux-continuum** | セッションの自動保存（15分ごと）・再起動時に自動復元 |
+
+> tmux-continuumの状態確認: `tmux show-option -gv @continuum-status`
+
 ## キーバインド
 | キー | 機能 |
 |------|------|


### PR DESCRIPTION
closes #91

## Summary

- `tmux-continuum` プラグインを追加（tmux-resurrectの後に読み込み）
- 15分ごとにセッションを自動保存
- 再起動時にセッションを自動復元
- docs/tmux.md にプラグイン一覧と状態確認コマンドを追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)