### PR TITLE
feat: fzf-tabでzshのTab補完をfzf UIに置き換える

### DIFF
--- a/.zsh/zsh_plugins.txt
+++ b/.zsh/zsh_plugins.txt
@@ -4,4 +4,5 @@ junegunn/fzf path:shell/completion.zsh
 junegunn/fzf path:shell/key-bindings.zsh
 zsh-users/zsh-autosuggestions
 zsh-users/zsh-syntax-highlighting
+Aloxaf/fzf-tab
 wfxr/forgit

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -8,6 +8,7 @@
 | **補完** | zsh-completions |
 | **ファジーファインダー** | fzf |
 | **シンタックスハイライト** | zsh-syntax-highlighting |
+| **Tab補完UI** | fzf-tab（Tab補完候補をfzfのインタラクティブUIで選択） |
 | **コマンド候補表示** | zsh-autosuggestions |
 
 ## エイリアス
@@ -53,9 +54,7 @@ navi が提供するキーバインド：
 
 | キー | 機能 |
 |------|------|
-| `Tab` | 補完候補を表示 / 候補を選択 |
-| `Ctrl+N` / `Ctrl+F` | 次の補完候補へ |
-| `Ctrl+P` / `Ctrl+B` | 前の補完候補へ |
+| `Tab` | fzf UIで補完候補をファジー絞り込み選択（fzf-tab） |
 
 ## fzf
 - デフォルトオプション: `--height 40% --layout=reverse --border`


### PR DESCRIPTION
closes #72

## Summary

- `Aloxaf/fzf-tab` を `zsh_plugins.txt` に追加（zsh-syntax-highlightingの後）
- Tab補完候補の選択がfzfのインタラクティブUIになる
- docs/zsh.md にfzf-tabの説明を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)