### PR TITLE
feat: vim-rooterでプロジェクトルートを自動検出してcwdを変更

### DIFF
--- a/.vim/myplugin-config/vim-rooter.vim
+++ b/.vim/myplugin-config/vim-rooter.vim
@@ -1,0 +1,3 @@
+" vim-rooter: .gitを基準にcwdをプロジェクトルートに自動変更
+
+let g:rooter_patterns = ['.git', '.git/']

--- a/.vim/plugin.vim
+++ b/.vim/plugin.vim
@@ -137,6 +137,9 @@ Plugin 'voldikss/vim-floaterm'
 " テストランナー
 Plugin 'vim-test/vim-test'
 
+" プロジェクトルートを自動検出してcwdを変更
+Plugin 'airblade/vim-rooter'
+
 " vim-airline
 if has('nvim')
     Plugin 'vim-airline/vim-airline'

--- a/.vimrc
+++ b/.vimrc
@@ -14,4 +14,5 @@ source $HOME/dotfiles/.vim/myplugin-config/which-key.vim
 source $HOME/dotfiles/.vim/myplugin-config/highlightedyank.vim
 source $HOME/dotfiles/.vim/myplugin-config/floaterm.vim
 source $HOME/dotfiles/.vim/myplugin-config/vim-test.vim
+source $HOME/dotfiles/.vim/myplugin-config/vim-rooter.vim
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -11,6 +11,7 @@
 | **Git連携** | vim-fugitive, vim-gitgutter |
 | **フローティングターミナル** | vim-floaterm（`<leader>tt`: ターミナル, `<leader>g`: lazygit） |
 | **テストランナー** | vim-test（`<leader>tn`: nearest, `<leader>tf`: file, `<leader>ts`: suite, `<leader>tl`: last） |
+| **プロジェクトルート検出** | vim-rooter（`.git`を基準にcwdを自動変更） |
 | **識別子ハイライト** | vim-illuminate（カーソル下の識別子を自動ハイライト） |
 | **ファジーファインダー** | fzf, fzf.vim |
 | **LaTeX** | vimtex |


### PR DESCRIPTION
closes #75

## Summary

- `airblade/vim-rooter` プラグインを追加
- `.git` を基準にVimのcwdをプロジェクトルートに自動変更
- サブディレクトリから起動してもfzfやNERDTreeが正しく動作するようになる
- docs/vim.md にvim-rooterの説明を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)