### PR TITLE
feat: NeovimをVimとは独立した設定で使えるようにする

### DIFF
--- a/.config/nvim/init.vim
+++ b/.config/nvim/init.vim
@@ -1,0 +1,3 @@
+set runtimepath^=~/.vim runtimepath+=~/.vim/after
+let &packpath = &runtimepath
+source ~/.vimrc

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -60,12 +60,24 @@
 | `<space>e` | 拡張機能一覧 |
 
 
+## Neovim設定
+
+Neovim は `~/.config/nvim/` を設定ディレクトリとして使用する。
+`dotfiles/.config/nvim/init.vim` が `~/.config/nvim/` にシンボリックリンクされており、既存の `.vimrc` をそのまま読み込む。
+
+```
+~/.config/nvim/init.vim  →  ~/dotfiles/.config/nvim/init.vim
+```
+
 ## プラグインのインストール
 
 ```bash
+# Neovim をインストール
+sudo snap install nvim --classic
+
 # Vundleをインストール
 git clone https://github.com/VundleVim/Vundle.vim ~/.vim/bundle/Vundle.vim
 
-# プラグインをインストール・依存関係のセットアップ
+# プラグインをインストール・依存関係のセットアップ（シンボリックリンク作成含む）
 bash scripts/install.sh
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,7 @@
 set -ue
 
 ln -s ~/dotfiles/.vimrc ~/.vimrc
+ln -s ~/dotfiles/.config/nvim ~/.config/nvim
 
 source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/powerline.sh
 source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/vim_deps.sh
@@ -12,6 +13,7 @@ install_delta
 setup_gitconfig
 
 sudo apt install -y eza fd-find nodejs npm groff fonts-noto-cjk fontconfig ripgrep
+sudo snap install nvim --classic
 
 # MesloLGS NF (powerlevel10k推奨フォント)
 FONT_DIR="$HOME/.local/share/fonts"


### PR DESCRIPTION
closes #121

## Summary

- `dotfiles/.config/nvim/init.vim` を新規作成し、既存の `.vimrc` をそのまま読み込むエントリーポイントとして設定
- `scripts/install.sh` に `snap install nvim --classic` と `~/.config/nvim` のシンボリックリンク作成を追加
- `docs/vim.md` にNeovim設定ディレクトリの説明を追加

## 移行方針

移行初期は既存の VimScript プラグイン群をそのまま Neovim でも使用する。
Powerline 設定は既に `if !has('nvim')` で除外済みのため変更不要。
次のステップとして issue #122（lazy.nvim移行）に続く。

🤖 Generated with [Claude Code](https://claude.com/claude-code)