### PR TITLE
feat: vim-auto-saveをautocmdに置き換えてプラグインを削減する

### DIFF
--- a/.config/nvim/lua/config/autocmds.lua
+++ b/.config/nvim/lua/config/autocmds.lua
@@ -20,6 +20,12 @@ autocmd("FileType", {
   end,
 })
 
+-- フォーカスが外れたとき・バッファ離脱時に自動保存
+autocmd({ "FocusLost", "BufLeave" }, {
+  pattern = "*",
+  command = "silent! wa",
+})
+
 -- ファイルタイプ別フォールド設定
 augroup("MyFolding", { clear = true })
 autocmd("FileType", {

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -23,15 +23,6 @@ return {
     end,
   },
 
-  -- オートセーブ
-  {
-    "vim-scripts/vim-auto-save",
-    event = "BufRead",
-    init = function()
-      vim.g.auto_save = 1
-    end,
-  },
-
   -- クイック実行
   { "thinca/vim-quickrun", cmd = "QuickRun" },
 

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -23,7 +23,7 @@
 | **コメントトグル** | vim-commentary（`gcc`: 行, `gc`: ビジュアル範囲） |
 | **インデントガイド** | indent-blankline.nvim |
 | **関数・クラス一覧** | tagbar（`Ctrl+t`でトグル） |
-| **オートセーブ** | vim-auto-save |
+| **オートセーブ** | autocmd（FocusLost/BufLeave で `silent! wa`） |
 | **Undoツリー可視化** | gundo.vim |
 | **クイック実行** | vim-quickrun |
 | **Markdownプレビュー** | markdown-preview.nvim（`:MarkdownPreview`、Mermaid対応） |


### PR DESCRIPTION
closes #128

## Summary

- `lua/plugins/editor.lua` から `vim-scripts/vim-auto-save` を削除
- `lua/config/autocmds.lua` に `FocusLost`/`BufLeave` で `silent! wa` する autocmd を追加
- `docs/vim.md` のオートセーブ記述を autocmd ベースに更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)