### PR TITLE
feat: vim-illuminateのハイライト遅延を調整してカーソル移動の体感を改善する

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -17,7 +17,8 @@ return {
     event = "BufRead",
     config = function()
       require("illuminate").configure({
-        delay = 250,
+        delay = 500,
+        min_count_to_highlight = 2,
         filetypes_denylist = { "NERDTree", "tagbar", "fzf" },
       })
     end,

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -13,7 +13,7 @@
 | **フローティングターミナル** | vim-floaterm（`<leader>tt`: ターミナル, `<leader>g`: lazygit） |
 | **テストランナー** | vim-test（floaterm連携） |
 | **プロジェクトルート検出** | vim-rooter（`.git`を基準にcwdを自動変更） |
-| **識別子ハイライト** | vim-illuminate（250ms遅延） |
+| **識別子ハイライト** | vim-illuminate（500ms遅延、2箇所以上一致でハイライト） |
 | **ファジーファインダー** | fzf, fzf.vim |
 | **LaTeX** | vimtex |
 | **コードフォーマット** | vim-prettier |


### PR DESCRIPTION
closes #129

## Summary

- `lua/plugins/editor.lua`: `delay` を 250ms → 500ms に変更、`min_count_to_highlight = 2` を追加
- `docs/vim.md`: illuminate の説明を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)