### PR TITLE
feat: gundo.vimをundotreeに置き換える

### DIFF
--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -60,6 +60,7 @@ local keymaps = {
   "n   <leader>tf   ファイル内テストを実行 (vim-test)",
   "n   <leader>ts   テストスイートを実行 (vim-test)",
   "n   <leader>tl   最後のテストを再実行 (vim-test)",
+  "n   <leader>u    Undoツリーをトグル (undotree)",
   "n   <leader>?    このキーバインド一覧を表示",
 }
 

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -28,7 +28,11 @@ return {
   { "thinca/vim-quickrun", cmd = "QuickRun" },
 
   -- Undoツリー可視化
-  { "sjl/gundo.vim", cmd = "GundoToggle" },
+  {
+    "mbbill/undotree",
+    cmd = "UndotreeToggle",
+    keys = { { "<leader>u", "<cmd>UndotreeToggle<CR>" } },
+  },
 
   -- 関数・クラス一覧（aerial）
   {

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -24,7 +24,7 @@
 | **インデントガイド** | indent-blankline.nvim |
 | **関数・クラス一覧** | aerial.nvim（`Ctrl+t`でトグル、LSP/treesitter連携） |
 | **オートセーブ** | autocmd（FocusLost/BufLeave で `silent! wa`） |
-| **Undoツリー可視化** | gundo.vim |
+| **Undoツリー可視化** | undotree（`<leader>u`でトグル） |
 | **クイック実行** | vim-quickrun |
 | **Markdownプレビュー** | markdown-preview.nvim（`:MarkdownPreview`、Mermaid対応） |
 | **キーバインド表示** | vim-which-key（`<leader>` 押下でポップアップ表示） |


### PR DESCRIPTION
closes #127

## Summary

- `sjl/gundo.vim` を削除（Python依存あり）
- `mbbill/undotree` を追加（`<leader>u` でトグル、Python依存なし）
- `keymaps.lua` の `<leader>?` 一覧に `<leader>u` を追加
- `docs/vim.md` のUndoツリー記述を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)