### PR TITLE
feat: splitright/splitbelowを設定して分割方向をVSCodeに合わせる

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -38,6 +38,8 @@ vim.opt.smarttab = true
 vim.opt.foldmethod = "marker"
 vim.opt.clipboard = "unnamed"
 vim.opt.mouse = "a"
+vim.opt.splitright = true
+vim.opt.splitbelow = true
 vim.opt.colorcolumn = "80"
 vim.opt.conceallevel = 2
 


### PR DESCRIPTION
closes #23

## Summary

- `vim.opt.splitright = true` を追加: 縦分割（`:vsp`）で右側に開くようになる
- `vim.opt.splitbelow = true` を追加: 横分割（`:sp`）で下側に開くようになる

🤖 Generated with [Claude Code](https://claude.com/claude-code)