### PR TITLE
feat: Neovim プラグインをコミットハッシュで固定する

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -3,17 +3,18 @@ return {
   { "windwp/nvim-autopairs", event = "InsertEnter", opts = {} },
 
   -- HTMLタグ補完
-  { "alvan/vim-closetag", ft = { "html", "xml" } },
+  { "alvan/vim-closetag", commit = "d0a562f8bdb107a50595aefe53b1a690460c3822", ft = { "html", "xml" } },
 
   -- コメントトグル (gcc: 行, gc: ビジュアル範囲)
-  { "tpope/vim-commentary", keys = { "gc", "gcc" } },
+  { "tpope/vim-commentary", commit = "64a654ef4a20db1727938338310209b6a63f60c9", keys = { "gc", "gcc" } },
 
   -- ナビゲーションマッピング
-  { "tpope/vim-unimpaired", event = "VeryLazy" },
+  { "tpope/vim-unimpaired", commit = "db65482581a28e4ccf355be297f1864a4e66985c", event = "VeryLazy" },
 
   -- カーソル下の識別子をハイライト
   {
     "RRethy/vim-illuminate",
+    commit = "0d1e93684da00ab7c057410fecfc24f434698898",
     event = "BufRead",
     config = function()
       require("illuminate").configure({
@@ -25,11 +26,12 @@ return {
   },
 
   -- クイック実行
-  { "thinca/vim-quickrun", cmd = "QuickRun" },
+  { "thinca/vim-quickrun", commit = "77b4d6ea9972a206f02c736882c2398c36d2983c", cmd = "QuickRun" },
 
   -- Undoツリー可視化
   {
     "mbbill/undotree",
+    commit = "6fa6b57cda8459e1e4b2ca34df702f55242f4e4d",
     cmd = "UndotreeToggle",
     keys = { { "<leader>u", "<cmd>UndotreeToggle<CR>" } },
   },
@@ -37,6 +39,7 @@ return {
   -- 関数・クラス一覧（aerial）
   {
     "stevearc/aerial.nvim",
+    commit = "645d108a5242ec7b378cbe643eb6d04d4223f034",
     keys = { { "<C-t>", "<cmd>AerialToggle<CR>", silent = true } },
     opts = {
       backends = { "lsp" },
@@ -47,6 +50,7 @@ return {
   -- プロジェクトルート自動検出
   {
     "airblade/vim-rooter",
+    commit = "51402fb77c4d6ae94994e37dc7ca13bec8f4afcc",
     event = "BufRead",
     init = function()
       vim.g.rooter_patterns = { ".git", ".git/" }
@@ -54,5 +58,5 @@ return {
   },
 
   -- コードフォーマット
-  { "prettier/vim-prettier", cmd = "Prettier", ft = { "javascript", "typescript", "css", "html", "json", "markdown" } },
+  { "prettier/vim-prettier", commit = "7dbdbb12c50a9f4ba72390cce2846248e4368fd0", cmd = "Prettier", ft = { "javascript", "typescript", "css", "html", "json", "markdown" } },
 }

--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -58,5 +58,10 @@ return {
   },
 
   -- コードフォーマット
-  { "prettier/vim-prettier", commit = "7dbdbb12c50a9f4ba72390cce2846248e4368fd0", cmd = "Prettier", ft = { "javascript", "typescript", "css", "html", "json", "markdown" } },
+  {
+    "prettier/vim-prettier",
+    commit = "7dbdbb12c50a9f4ba72390cce2846248e4368fd0",
+    cmd = "Prettier",
+    ft = { "javascript", "typescript", "css", "html", "json", "markdown" },
+  },
 }

--- a/.config/nvim/lua/plugins/git.lua
+++ b/.config/nvim/lua/plugins/git.lua
@@ -1,10 +1,11 @@
 return {
   -- Git操作
-  { "tpope/vim-fugitive", cmd = { "Git", "G" } },
+  { "tpope/vim-fugitive", commit = "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0", cmd = { "Git", "G" } },
 
   -- Git差分をガターに表示（vim-gitgutter → gitsigns.nvim）
   {
     "lewis6991/gitsigns.nvim",
+    commit = "6d808f99bd63303646794406e270bd553ad7792e",
     event = "BufRead",
     opts = {
       signs = {

--- a/.config/nvim/lua/plugins/lang.lua
+++ b/.config/nvim/lua/plugins/lang.lua
@@ -1,10 +1,11 @@
 return {
   -- LaTeX
-  { "lervag/vimtex", ft = "tex" },
+  { "lervag/vimtex", commit = "0f42a5130432d4af2e6fd21fb93a76915ff1f090", ft = "tex" },
 
   -- Markdownプレビュー
   {
     "iamcco/markdown-preview.nvim",
+    commit = "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee",
     cmd = { "MarkdownPreview", "MarkdownPreviewStop" },
     ft = "markdown",
     build = "cd app && npm install",
@@ -18,6 +19,7 @@ return {
   -- フローティングターミナル
   {
     "voldikss/vim-floaterm",
+    commit = "0ab5eb8135dc884bc543a819ac7033c15e72a76b",
     cmd = { "FloatermNew", "FloatermToggle" },
     keys = {
       { "<leader>tt", "<cmd>FloatermToggle<CR>", mode = { "n", "t" }, silent = true },
@@ -33,6 +35,7 @@ return {
   -- テストランナー
   {
     "vim-test/vim-test",
+    commit = "bc0e94059de40641d163516a83c63bc45c716acf",
     cmd = { "TestNearest", "TestFile", "TestSuite", "TestLast" },
     keys = {
       { "<leader>tn", ":TestNearest<CR>", silent = true },

--- a/.config/nvim/lua/plugins/lsp.lua
+++ b/.config/nvim/lua/plugins/lsp.lua
@@ -2,6 +2,7 @@ return {
   -- LSPサーバー管理
   {
     "williamboman/mason.nvim",
+    commit = "cb8445f8ce85d957416c106b780efd51c6298f89",
     cmd = "Mason",
     build = ":MasonUpdate",
     opts = {},
@@ -12,10 +13,11 @@ return {
   -- 新しいサーバーを追加するときは ensure_installed に名前を追加するだけでよい
   {
     "williamboman/mason-lspconfig.nvim",
+    commit = "0c2823e0418f3d9230ff8b201c976e84de1cb401",
     dependencies = {
-      "williamboman/mason.nvim",
-      "neovim/nvim-lspconfig",
-      "hrsh7th/cmp-nvim-lsp",
+      { "williamboman/mason.nvim", commit = "cb8445f8ce85d957416c106b780efd51c6298f89" },
+      { "neovim/nvim-lspconfig", commit = "6419b36f50c42420cbbf1d3ffba573094cf414c8" },
+      { "hrsh7th/cmp-nvim-lsp", commit = "cbc7b02bb99fae35cb42f514762b89b5126651ef" },
     },
     event = { "BufReadPre", "BufNewFile" },
     config = function()
@@ -57,13 +59,14 @@ return {
   -- 補完エンジン
   {
     "hrsh7th/nvim-cmp",
+    commit = "a1d504892f2bc56c2e79b65c6faded2fd21f3eca",
     event = "InsertEnter",
     dependencies = {
-      "hrsh7th/cmp-nvim-lsp",
-      "hrsh7th/cmp-buffer",
-      "hrsh7th/cmp-path",
-      "L3MON4D3/LuaSnip",
-      "saadparwaiz1/cmp_luasnip",
+      { "hrsh7th/cmp-nvim-lsp", commit = "cbc7b02bb99fae35cb42f514762b89b5126651ef" },
+      { "hrsh7th/cmp-buffer", commit = "b74fab3656eea9de20a9b8116afa3cfc4ec09657" },
+      { "hrsh7th/cmp-path", commit = "c642487086dbd9a93160e1679a1327be111cbc25" },
+      { "L3MON4D3/LuaSnip", commit = "a62e1083a3cfe8b6b206e7d3d33a51091df25357" },
+      { "saadparwaiz1/cmp_luasnip", commit = "98d9cb5c2c38532bd9bdb481067b20fea8f32e90" },
     },
     config = function()
       local cmp = require("cmp")

--- a/.config/nvim/lua/plugins/search.lua
+++ b/.config/nvim/lua/plugins/search.lua
@@ -2,17 +2,24 @@ return {
   -- fzf本体
   {
     "junegunn/fzf",
+    commit = "6fefe025461b168eac2546ccba3403b70eb5da16",
     build = "./install --bin",
     lazy = true,
   },
 
   -- fzf vim統合
-  { "junegunn/fzf.vim", dependencies = { "junegunn/fzf" }, event = "VeryLazy" },
+  {
+    "junegunn/fzf.vim",
+    commit = "b9624aa012ddcbae9e79964bfd30cc1fbe3cf263",
+    dependencies = { { "junegunn/fzf", commit = "6fefe025461b168eac2546ccba3403b70eb5da16" } },
+    event = "VeryLazy",
+  },
 
   -- ファイルツリー
   {
     "nvim-tree/nvim-tree.lua",
-    dependencies = { "nvim-tree/nvim-web-devicons" },
+    commit = "24cfcc94372e526fd9e1c2803ede9e0f1715e33f",
+    dependencies = { { "nvim-tree/nvim-web-devicons", commit = "4fc505ac7bd7692824a142e96e5f529c133862f8" } },
     keys = { { "<C-e>", "<cmd>NvimTreeToggle<CR>", silent = true } },
     opts = {
       git = { enable = true },

--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -1,10 +1,11 @@
 return {
   -- カラースキーム
-  { "tomasr/molokai", lazy = false, priority = 1000 },
+  { "tomasr/molokai", commit = "c67bdfcdb31415aa0ade7f8c003261700a885476", lazy = false, priority = 1000 },
 
   -- ステータスライン（vim-airline → lualine）
   {
     "nvim-lualine/lualine.nvim",
+    commit = "131a558e13f9f28b15cd235557150ccb23f89286",
     event = "VimEnter",
     opts = { theme = "auto" },
   },
@@ -12,6 +13,7 @@ return {
   -- インデントガイド（indentLine → indent-blankline）
   {
     "lukas-reineke/indent-blankline.nvim",
+    commit = "d28a3f70721c79e3c5f6693057ae929f3d9c0a03",
     main = "ibl",
     event = "BufRead",
     opts = {
@@ -22,6 +24,7 @@ return {
   -- キーバインド一覧
   {
     "liuchengxu/vim-which-key",
+    commit = "72a4267b46a76f541b3e9500a7503575575d4f57",
     event = "VeryLazy",
     config = function()
       vim.g.which_key_map = {
@@ -50,6 +53,7 @@ return {
   -- ヤンクのハイライト（300ms）
   {
     "machakann/vim-highlightedyank",
+    commit = "285a61425e79742997bbde76a91be6189bc988fb",
     event = "VeryLazy",
     init = function()
       vim.g.highlightedyank_highlight_duration = 300
@@ -57,5 +61,5 @@ return {
   },
 
   -- CSSカラープレビュー
-  { "ap/vim-css-color", event = "VeryLazy" },
+  { "ap/vim-css-color", commit = "14fd934cdd9ca1ac0e53511094e612eb9bace373", event = "VeryLazy" },
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,5 +44,5 @@ else
   echo "    https://rustup.rs/"
 fi
 # lazy.nvim プラグインをヘッドレスでインストール
-nvim --headless "+Lazy! sync" +qa
+nvim --headless "+Lazy! restore" +qa
 vim_deps


### PR DESCRIPTION
## Summary

- 全プラグイン定義ファイル（`plugins/*.lua`）に `commit = "..."` を追加し、バージョンを明示的に固定
- `scripts/install.sh` の `Lazy! sync` を `Lazy! restore` に変更し、`lazy-lock.json` を正しく利用するように修正

## 注意

- `nvim-autopairs` は `lazy-lock.json` に未登録のため `commit` 未指定。一度 `:Lazy sync` を実行して lock に追記してから追加すること

## Test plan

- [ ] Neovim を起動してプラグインが正常に読み込まれることを確認
- [ ] `:Lazy` でプラグインの状態を確認し、全プラグインがインストール済みであることを確認

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)