### PR TITLE
fix: 再起動後に WezTerm で日本語入力が使えなくなる問題を修正する

### DIFF
--- a/.config/autostart/setup-wezterm-ime.desktop
+++ b/.config/autostart/setup-wezterm-ime.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Setup WezTerm IME
+Comment=Set ibus environment variables for WezTerm Flatpak
+Exec=bash -c 'exec "$HOME/dotfiles/scripts/setup_wezterm_ime.sh"'
+NoDisplay=true
+X-GNOME-Autostart-enabled=true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,11 @@ set -ue
 
 ln -s ~/dotfiles/.config/nvim ~/.config/nvim
 
+# WezTerm IME autostart (GNOME セッション開始時に自動で ibus Flatpak override を適用)
+mkdir -p ~/.config/autostart
+ln -sf ~/dotfiles/.config/autostart/setup-wezterm-ime.desktop ~/.config/autostart/setup-wezterm-ime.desktop
+bash ~/dotfiles/scripts/setup_wezterm_ime.sh
+
 source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/vim_deps.sh
 source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/git.sh
 


### PR DESCRIPTION
## Summary

- GNOME セッション開始時に `setup_wezterm_ime.sh` を自動実行する autostart エントリ（`.config/autostart/setup-wezterm-ime.desktop`）を追加
- `install.sh` に autostart シンボリックリンク作成と `setup_wezterm_ime.sh` 実行を追加

## 原因

WezTerm は Flatpak インストールのため、ibus 用環境変数（`XMODIFIERS=@im=ibus` 等）は `flatpak override` で設定する必要がある。`setup_wezterm_ime.sh` でこれを設定しているが、毎回 PC 再起動後に手動実行が必要だった。

GNOME autostart にスクリプトを登録することで、ログイン時に自動実行され、**WezTerm を開き直すだけで日本語入力が機能する**ようになる。

## Test plan

- [ ] PC を再起動する
- [ ] ログイン後、WezTerm を開く
- [ ] 日本語入力（ibus-mozc）が使えることを確認する
- [ ] `~/.config/autostart/setup-wezterm-ime.desktop` が存在することを確認する
- [ ] `flatpak override --user --show org.wezfurlong.wezterm` で `XMODIFIERS=@im=ibus` が設定されていることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)