### PR TITLE
fix: Ctrl+Shift+P でコマンドパレットを開けるようにする

### DIFF
--- a/.wezterm/keybinds.lua
+++ b/.wezterm/keybinds.lua
@@ -34,7 +34,6 @@ M.tmux_keybinds = {
 
 M.default_keybinds = {
     { key='C', mods='CTRL', action=act.CopyTo 'Clipboard' },
-    { key='P', mods='CTRL', action=act.PasteFrom 'Clipboard' },
     { key='F9', mods='ALT', action=act.ShowTabNavigator },
 }
 


### PR DESCRIPTION
closes #144

## Summary

- `key='P', mods='CTRL'` のペースト設定を削除し、WezTerm デフォルトの `Ctrl+Shift+P` コマンドパレットを復活させる
- ペーストは WezTerm デフォルトの `Ctrl+Shift+V` をそのまま使用する

🤖 Generated with [Claude Code](https://claude.com/claude-code)