### PR TITLE
feat: Claude Code応答時にWezTermタブへマーカーを表示する

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/dotfiles/.claude/hooks/claude_notify.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/dotfiles/.claude/hooks/claude_notify.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/hooks/claude_notify.sh
+++ b/.claude/hooks/claude_notify.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+printf '\a'

--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -25,6 +25,33 @@ local function set_battery_info()
     end)
 end
 
+-- Claude Code応答通知: bellが来たタブIDを記録する
+local bell_tabs = {}
+
+wezterm.on('bell', function(window, pane)
+    local tab = pane:tab()
+    if tab then
+        bell_tabs[tab:tab_id()] = true
+        window:active_tab():invalidate()
+    end
+end)
+
+-- アクティブになったらマーカーをクリアする
+wezterm.on('focus-changed', function(window, pane)
+    local tab = window:active_tab()
+    if tab then
+        bell_tabs[tab:tab_id()] = nil
+    end
+end)
+
+wezterm.on('format-tab-title', function(tab, tabs, panes, config, hover, max_width)
+    local title = tab.active_pane.title
+    if bell_tabs[tab.tab_id] then
+        return '● ' .. title
+    end
+    return title
+end)
+
 
 return {
     ----------------------------------------------------

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,7 +14,7 @@ source $(dirname "${BASH_SOURCE[0]:-$0}")/lib/git.sh
 install_delta
 setup_gitconfig
 
-sudo apt install -y eza fd-find nodejs npm groff fonts-noto-cjk fontconfig ripgrep
+sudo apt install -y eza fd-find nodejs npm groff fonts-noto-cjk fontconfig ripgrep jq
 sudo snap install nvim --classic
 
 # MesloLGS NF (powerlevel10k推奨フォント)
@@ -51,3 +51,12 @@ fi
 # lazy.nvim プラグインをヘッドレスでインストール
 nvim --headless "+Lazy! restore" +qa
 vim_deps
+
+# Claude Code hooks設定を~/.claude/settings.jsonにマージ
+mkdir -p ~/.claude
+if [ -f ~/.claude/settings.json ]; then
+    jq -s '.[0] * .[1]' ~/.claude/settings.json ~/dotfiles/.claude/hooks.json > /tmp/claude_settings_merged.json
+    mv /tmp/claude_settings_merged.json ~/.claude/settings.json
+else
+    cp ~/dotfiles/.claude/hooks.json ~/.claude/settings.json
+fi


### PR DESCRIPTION
## Summary

- `.claude/hooks/claude_notify.sh` を新規追加 — ベル信号を送る通知スクリプト
- `.claude/hooks.json` を新規追加 — `Notification`/`Stop` フックの設定を `~/.claude/settings.json` から切り出して管理
- `scripts/install.sh` に `jq` と hooks マージ処理を追加 — インストール時に `hooks.json` を `settings.json` へマージ
- `.wezterm.lua` に bell 検知・タブマーカー表示を追加 — 別タブ作業中に Claude の応答完了を `●` マーカーで視認できる

参考: https://zenn.dev/dely_jp/articles/5d4e89c275789f

🤖 Generated with [Claude Code](https://claude.com/claude-code)