### PR TITLE
feat: WezTermにunix_domainを設定してセッションを永続化する

### DIFF
--- a/.wezterm.lua
+++ b/.wezterm.lua
@@ -91,4 +91,12 @@ return {
     font = make_font(),
     font_size = 13,
     line_height = 1.0,
+
+    ----------------------------------------------------
+    -- session
+    ----------------------------------------------------
+    unix_domains = {
+        { name = "unix" },
+    },
+    default_gui_startup_args = { "connect", "unix" },
 }

--- a/docs/wezterm.md
+++ b/docs/wezterm.md
@@ -11,10 +11,17 @@
 | **フォント** | MesloLGS NF（fallback: Noto Sans Mono CJK JP, Noto Color Emoji） |
 | **ペイン分割線** | cyan（`#00ffff`） |
 | **非アクティブペイン** | 彩度0.5・明度0.6で暗く表示 |
+| **セッション永続化** | unix_domain によりウィンドウを閉じてもセッションが継続 |
 
 ## フォント
 
 `MesloLGS NF` を使用している。フォントファイルは `fonts/` に同梱されており、`scripts/install.sh` によって `~/.local/share/fonts/` にコピーされる。
+
+## セッション永続化
+
+`unix_domain` を使ってWezTermをデーモンとして常駐させる。ウィンドウを閉じてもセッションが生き続け、再起動後も `wezterm connect unix` で既存セッションにアタッチできる。
+
+`default_gui_startup_args = { "connect", "unix" }` により、WezTerm起動時に自動的にunixドメインへ接続する。
 
 ## キーバインド
 


### PR DESCRIPTION
closes #149

## Summary

- `.wezterm.lua` に `unix_domains` と `default_gui_startup_args` を追加
- WezTermのウィンドウを閉じてもセッションが継続するようになる
- `wezterm connect unix` で既存セッションに再アタッチ可能
- `docs/wezterm.md` にセッション永続化の説明を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)