### PR TITLE
feat: vim-matchupで%マッチングをNeovimで強化する

### DIFF
--- a/docs/vim.md
+++ b/docs/vim.md
@@ -17,6 +17,7 @@
 | **ファジーファインダー** | fzf, fzf.vim |
 | **LaTeX** | vimtex |
 | **コードフォーマット** | vim-prettier |
+| **%マッチング強化** | vim-matchup（`%`でif/end, do/endなどの構文キーワードにもジャンプ） |
 | **括弧・クォート自動補完** | auto-pairs |
 | **HTMLタグ補完** | vim-closetag |
 | **CSSカラープレビュー** | vim-css-color |

--- a/nvim/lua/plugins/editor.lua
+++ b/nvim/lua/plugins/editor.lua
@@ -57,6 +57,9 @@ return {
     end,
   },
 
+  -- %マッチング強化（if/end, do/end などの構文キーワードにも対応）
+  { "andymass/vim-matchup", event = "BufRead" },
+
   -- コードフォーマット
   {
     "prettier/vim-prettier",


### PR DESCRIPTION
closes #84

## Summary

- `nvim/lua/plugins/editor.lua` に vim-matchup を追加
- `%` で括弧だけでなく if/end、do/end などの構文キーワードにもジャンプ可能に
- `docs/vim.md` に vim-matchup の設定を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)